### PR TITLE
keep original redmine id

### DIFF
--- a/python/redmine2youtrack.py
+++ b/python/redmine2youtrack.py
@@ -366,6 +366,7 @@ class RedmineImporter(object):
         project_id = project.identifier
         offset = 0
         assignee_group = self._get_assignee_group_name(project_id)
+        self._create_field(project_id, 'redmine-id', 'integer')
         while True:
             issues = self._source.get_project_issues(project.id, limit, offset)
             if not issues:
@@ -384,6 +385,7 @@ class RedmineImporter(object):
     def _make_issue(self, redmine_issue, project_id):
         issue = youtrack.Issue()
         issue['comments'] = []
+        issue['redmine-id'] = redmine_issue.attributes['id']
         try:
             for name, value in redmine_issue.attributes.items():
                 if name in ('project', 'attachments'):
@@ -392,6 +394,7 @@ class RedmineImporter(object):
                     continue
                 if name == 'id':
                     value = str(self._get_yt_issue_number(redmine_issue))
+
                 if name == 'custom_fields':
                     for field in value:
                         self._add_field_to_issue(


### PR DESCRIPTION
This modification adds the ID of the original redmine ticket as a field to the new youtrack ticket. That is essential, if you have references in code or vcs log to the original IDs.
