### PR TITLE
Adding getTracking method

### DIFF
--- a/python/youtrack/__init__.py
+++ b/python/youtrack/__init__.py
@@ -253,7 +253,10 @@ class WorkItem(YouTrackObject):
             xml = xml.documentElement
         self.workitem_date = int(self._text(xml.getElementsByTagName('date')[0]))
         self.workitem_duration = int(self._text(xml.getElementsByTagName('duration')[0]))
-        self.description = self._text(xml.getElementsByTagName('description')[0])
+        try:
+            self.description = self._text(xml.getElementsByTagName('description')[0])
+        except IndexError:
+            pass
         self.author = xml.getElementsByTagName('author')[0].getAttribute('login')
 
 class IssueChange(YouTrackObject):

--- a/python/youtrack/__init__.py
+++ b/python/youtrack/__init__.py
@@ -238,6 +238,24 @@ class Comment(YouTrackObject):
         return self.youtrack.getUser(self.author)
 
 
+class WorkItem(YouTrackObject):
+    def __init__(self, xml=None, youtrack=None):
+        self.workitem_date = 0
+        self.workitem_duration = 0
+        self.description = ''
+        self.author = ''
+        YouTrackObject.__init__(self, xml, youtrack)
+
+    def _update(self, xml):
+        if xml is None:
+            return
+        if isinstance(xml, Document):
+            xml = xml.documentElement
+        self.workitem_date = int(self._text(xml.getElementsByTagName('date')[0]))
+        self.workitem_duration = int(self._text(xml.getElementsByTagName('duration')[0]))
+        self.description = self._text(xml.getElementsByTagName('description')[0])
+        self.author = xml.getElementsByTagName('author')[0].getAttribute('login')
+
 class IssueChange(YouTrackObject):
     def __init__(self, xml=None, youtrack=None):
         self.fields = []

--- a/python/youtrack/connection.py
+++ b/python/youtrack/connection.py
@@ -147,6 +147,10 @@ class Connection(object):
         response, content = self._req('GET', '/issue/' + id + '/comment')
         xml = minidom.parseString(content)
         return [youtrack.Comment(e, self) for e in xml.documentElement.childNodes if e.nodeType == Node.ELEMENT_NODE]
+    
+    def getTracking(self, id):
+        return [youtrack.WorkItem(workitem, self) for workitem in
+                self._get("/issue/%s/timetracking/workitem/" % id).getElementsByTagName('workItem')]
 
     def getAttachments(self, id):
         response, content = self._req('GET', '/issue/' + id + '/attachment')


### PR DESCRIPTION
The following api was not implemented in python client library for youtrack api:
https://confluence.jetbrains.com/display/YTD65/Get+Available+Work+Items+of+Issue
