### PR TITLE
jira client - fix for getting attachment content

### DIFF
--- a/python/jira/client.py
+++ b/python/jira/client.py
@@ -69,5 +69,5 @@ class JiraClient(object):
     def _login(self, login, password):
         # response, content = self._post(self._url + "/auth/1/session", {"username": login, "password": password})
         # self._headers['JSESSIONID'] = content['session']['value']
-        auth = base64.encodestring(login + ':' + password)
+        auth = base64.b64encode(login + ':' + password)
         self._headers['Authorization'] = 'Basic ' + auth


### PR DESCRIPTION
'Authorization' header value is encoded with `base64.encodestring` which adds a trailing newline. While most calls just work, fetching attachment contents does not.

Using the newer `base64.b64encode` which strips the trailing newline fix the problem.