### PR TITLE
fix type error in request with body

### DIFF
--- a/youtrack/connection.py
+++ b/youtrack/connection.py
@@ -99,7 +99,7 @@ class Connection(object):
                 #    body = re.sub(self.__get_illegal_xml_chars_re(), b'', body)
 
                 headers['Content-Type'] = content_type
-                headers['Content-Length'] = len(body)
+                headers['Content-Length'] = str(len(body))
         elif method == 'GET' and content_type is not None:
             headers = headers.copy()
             headers['Accept'] = content_type


### PR DESCRIPTION
When a request has a body, such as one made by executeCommand, header
Content-Length is given a value of type int. That was causing
httplib2._convert_byte_str to throw an error.