### PR TITLE
fix type error in getAttachmentContent

### DIFF
--- a/youtrack/__init__.py
+++ b/youtrack/__init__.py
@@ -327,7 +327,7 @@ class Attachment(YouTrackObject):
         self.url = re.sub(r'^.*?(?=/_persistent)', '', self.url)
 
     def getContent(self):
-        return self.youtrack.getAttachmentContent(self.url.encode('utf-8'))
+        return self.youtrack.getAttachmentContent(self.url)
 
     def getAuthor(self):
         if self.authorLogin == '<no user>':


### PR DESCRIPTION
When Attachment's getContent it shouldn't convert it to bytes, because
getAttachmentContent concatenates it with the base URL, which is str.